### PR TITLE
feat: 면접 합/불합격자 문자 템플릿 변수 치환 기능 구현

### DIFF
--- a/src/components/interview/ApplicantMessageCard.tsx
+++ b/src/components/interview/ApplicantMessageCard.tsx
@@ -10,9 +10,11 @@ import type { InterviewApplicant } from '@/types/interview';
 
 interface ApplicantMessageCardProps {
   type: '합격자' | '불합격자';
+  template?: string;
+  isVariableEnabled?: boolean;
 }
 
-export default function ApplicantMessageCard({ type }: ApplicantMessageCardProps) {
+export default function ApplicantMessageCard({ type, template, isVariableEnabled = false }: ApplicantMessageCardProps) {
   const [isPersonalMessageOpen, setIsPersonalMessageOpen] = useState(false);
   const [selectedApplicant, setSelectedApplicant] = useState<InterviewApplicant | null>(null);
 
@@ -22,6 +24,59 @@ export default function ApplicantMessageCard({ type }: ApplicantMessageCardProps
   const handleApplicantClick = (applicant: InterviewApplicant) => {
     setSelectedApplicant(applicant);
     setIsPersonalMessageOpen(true);
+  };
+
+  // 변수를 실제 값으로 치환하는 함수
+  const replaceVariables = (text: string, applicant: InterviewApplicant) => {
+    return text
+      .replace(/[@＠]이름/g, applicant.name)
+      .replace(/[@＠]포지션/g, applicant.position);
+  };
+
+  // 변수가 치환된 부분을 파랑색으로 표시하기 위한 함수
+  const renderTemplateWithHighlight = (text: string, applicant: InterviewApplicant) => {
+    const parts: React.ReactNode[] = [];
+    let lastIndex = 0;
+    let keyCounter = 0;
+    
+    // @이름과 @포지션을 찾아서 치환 (전각문자 @도 포함)
+    const regex = /[@＠]이름|[@＠]포지션/g;
+    let match;
+    
+    while ((match = regex.exec(text)) !== null) {
+      // 일반 텍스트 부분
+      if (match.index > lastIndex) {
+        const normalText = text.substring(lastIndex, match.index);
+        parts.push(
+          <span key={`text-${keyCounter++}`}>
+            {normalText}
+          </span>
+        );
+      }
+      
+      // 치환된 변수 부분 (파랑색으로 표시)
+      const variable = match[0];
+      const value = variable.includes('이름') ? applicant.name : applicant.position;
+      parts.push(
+        <span key={`var-${keyCounter++}`} className="text-primary">
+          {value}
+        </span>
+      );
+      
+      lastIndex = regex.lastIndex;
+    }
+    
+    // 마지막 남은 텍스트
+    if (lastIndex < text.length) {
+      const remainingText = text.substring(lastIndex);
+      parts.push(
+        <span key={`text-${keyCounter++}`}>
+          {remainingText}
+        </span>
+      );
+    }
+    
+    return parts;
   };
 
   const title = type === '합격자' ? '합격자 개인별 메세지' : '불합격자 개인별 메세지';
@@ -34,6 +89,21 @@ export default function ApplicantMessageCard({ type }: ApplicantMessageCardProps
       ? '합격자 오리엔테이션 일정과 안내 자료는 별도로 전달드릴 예정이니 확인 부탁드립니다.'
       : '지원해 주셔서 감사드리며, 다음 기회에 다시 뵙기를 바랍니다.';
 
+  const handleCopyMessage = () => {
+    if (selectedApplicant && template) {
+      const message = isVariableEnabled 
+        ? replaceVariables(template, selectedApplicant)
+        : template;
+      navigator.clipboard.writeText(message);
+    }
+  };
+
+  const handleCopyPhone = () => {
+    if (selectedApplicant?.phone) {
+      navigator.clipboard.writeText(selectedApplicant.phone);
+    }
+  };
+
   return (
     <>
       <div className="mt-3">
@@ -42,7 +112,7 @@ export default function ApplicantMessageCard({ type }: ApplicantMessageCardProps
         <div className="flex items-center gap-2.5 mb-1">
           <button className="flex items-center gap-1 text-gray-400 text-[12px] font-medium leading-[22px]">
             <Image src="/icons/copy-gray.svg" alt="명단 복사하기" width={15} height={15} />
-            <span>명단 복사하기</span>
+            <span>문자 복사하기</span>
           </button>
           <button className="flex items-center gap-1 text-gray-400 text-[12px] font-medium leading-[22px]">
             <Image src="/icons/hashtag-gray.svg" alt="전화번호 복사하기" width={15} height={15} />
@@ -74,11 +144,21 @@ export default function ApplicantMessageCard({ type }: ApplicantMessageCardProps
             </h3>
             {/* 버튼 */}
             <div className="flex gap-2 justify-center items-center pt-3">
-              <Button variant="outline" size="md" className="inline-flex items-center justify-center gap-1">
-                <span>명단 복사하기</span>
+              <Button 
+                variant="outline" 
+                size="md" 
+                className="inline-flex items-center justify-center gap-1"
+                onClick={handleCopyMessage}
+              >
+                <span>문자 복사하기</span>
                 <Image src="/icons/copy-blue.svg" alt="" width={15} height={15} />
               </Button>
-              <Button variant="outline" size="md" className="inline-flex items-center justify-center gap-1">
+              <Button 
+                variant="outline" 
+                size="md" 
+                className="inline-flex items-center justify-center gap-1"
+                onClick={handleCopyPhone}
+              >
                 <span>전화번호 복사하기</span>
                 <Image src="/icons/tag-blue.svg" alt="" width={15} height={15} />
               </Button>
@@ -86,15 +166,28 @@ export default function ApplicantMessageCard({ type }: ApplicantMessageCardProps
 
             {/* 템플릿 텍스트 */}
             <div className="flex flex-col gap-4 py-4 text-body-sm-rg">
-              <h2>[요리퐁 6기 최종 결과 안내]</h2>
+              {template ? (
+                // 커스텀 템플릿이 있을 경우
+                <div className="whitespace-pre-wrap">
+                  {isVariableEnabled 
+                    ? renderTemplateWithHighlight(template, selectedApplicant)
+                    : template
+                  }
+                </div>
+              ) : (
+                // 기본 템플릿
+                <>
+                  <h2>[요리퐁 6기 최종 결과 안내]</h2>
 
-              <div>
-                <p>
-                  <span className="text-primary">{selectedApplicant.name}</span> 님, {resultText}
-                </p>
-              </div>
+                  <div>
+                    <p>
+                      <span className="text-primary">{selectedApplicant.name}</span> @이름 님, {resultText}
+                    </p>
+                  </div>
 
-              <p>{additionalText}</p>
+                  <p>{additionalText}</p>
+                </>
+              )}
             </div>
           </>
         )}

--- a/src/components/interview/InterviewFailedList.tsx
+++ b/src/components/interview/InterviewFailedList.tsx
@@ -1,14 +1,32 @@
-import ApplicantCountHeader from '@/components/interview/ApplicantCountHeader';
+'use client';
+
+import { useState } from 'react';
 import Button from '@/components/ui/Btn';
-import ApplicantMessageCard from '@/components/interview/ApplicantMessageCard';
 import NotificationMessageForm from '@/components/ui/NotificationMessageForm';
+import ApplicantCountHeader from '@/components/interview/ApplicantCountHeader';
+import ApplicantMessageCard from '@/components/interview/ApplicantMessageCard';
 
 export default function InterviewFailedList() {
+  const [template, setTemplate] = useState('');
+  const [isVariableEnabled, setIsVariableEnabled] = useState(false);
+
+  const handleTemplateApply = (appliedTemplate: string, variableEnabled: boolean) => {
+    setTemplate(appliedTemplate);
+    setIsVariableEnabled(variableEnabled);
+  };
+
   return (
     <>
       <ApplicantCountHeader type="불합격자" />
-      <NotificationMessageForm type="불합격자" />
-      <ApplicantMessageCard type="불합격자" />
+      <NotificationMessageForm 
+        type="불합격자" 
+        onTemplateApply={handleTemplateApply}
+      />
+      <ApplicantMessageCard 
+        type="불합격자" 
+        template={template}
+        isVariableEnabled={isVariableEnabled}
+      />
       <div className="bg-gray-50">
         <Button variant="primary" size="lg" className="fixed bottom-20">
           면접 마감하기

--- a/src/components/interview/InterviewPassedList.tsx
+++ b/src/components/interview/InterviewPassedList.tsx
@@ -1,15 +1,33 @@
-import ApplicantCountHeader from '@/components/interview/ApplicantCountHeader';
+'use client';
+
+import { useState } from 'react';
 import Button from '@/components/ui/Btn';
-import ApplicantMessageCard from '@/components/interview/ApplicantMessageCard';
 import NotificationMessageForm from '@/components/ui/NotificationMessageForm';
+import ApplicantCountHeader from '@/components/interview/ApplicantCountHeader';
+import ApplicantMessageCard from '@/components/interview/ApplicantMessageCard';
 import Link from 'next/link';
 
 export default function InterviewPassedList() {
+  const [template, setTemplate] = useState('');
+  const [isVariableEnabled, setIsVariableEnabled] = useState(false);
+
+  const handleTemplateApply = (appliedTemplate: string, variableEnabled: boolean) => {
+    setTemplate(appliedTemplate);
+    setIsVariableEnabled(variableEnabled);
+  };
+
   return (
     <>
       <ApplicantCountHeader type="합격자" />
-      <NotificationMessageForm type="합격자" />
-      <ApplicantMessageCard type="합격자" />
+      <NotificationMessageForm 
+        type="합격자" 
+        onTemplateApply={handleTemplateApply}
+      />
+      <ApplicantMessageCard 
+        type="합격자" 
+        template={template}
+        isVariableEnabled={isVariableEnabled}
+      />
       <Link href="/interview/complete" className="">
         <Button variant="primary" size="lg" className="fixed bottom-20">
           면접 마감하기


### PR DESCRIPTION
## 📝 작업 내용

- 문자 템플릿 입력 시 @이름 변수 사용 가능
- 변수 적용하기 버튼으로 변수 치환 활성화
- 템플릿 복사하기 버튼으로 지원자 개인별 탭에 메시지 반영
- 변수 적용 시 텍스트박스와 개인별 바텀시트에서 치환된 변수를 파랑색으로 하이라이트
- contentEditable을 사용하여 변수 적용 후에도 텍스트 수정 가능
- 템플릿 수정 시 변수 적용 상태 자동 리셋


## 🔗 관련 이슈

resolves #
