### PR TITLE
fix: 서류 재활성화 관련 이슈 해결

### DIFF
--- a/src/components/document/DocumentResultContent.tsx
+++ b/src/components/document/DocumentResultContent.tsx
@@ -13,6 +13,9 @@ interface DocumentResultContentProps {
   projectId: number;
 }
 
+const sortByName = (list: DocumentApplicantResult[]) =>
+  [...list].sort((a, b) => a.name.localeCompare(b.name, 'ko'));
+
 export default function DocumentResultContent({ projectId }: DocumentResultContentProps) {
   const [selectedTab, setSelectedTab] = useState<'합격자' | '불합격자'>('합격자');
   const [stats, setStats] = useState<DocumentResultStats | null>(null);
@@ -26,6 +29,7 @@ export default function DocumentResultContent({ projectId }: DocumentResultConte
   const [failedIsVariableEnabled, setFailedIsVariableEnabled] = useState(false);
   const [isLoaded, setIsLoaded] = useState(false);
 
+  
   useEffect(() => {
     const fetchResults = async () => {
       const [passedRes, failedRes] = await Promise.all([
@@ -33,8 +37,8 @@ export default function DocumentResultContent({ projectId }: DocumentResultConte
         documentResultService.getDocumentResults(projectId, 'FAIL'),
       ]);
       setStats(passedRes.stats);
-      setPassedList(passedRes.applicants);
-      setFailedList(failedRes.applicants);
+      setPassedList(sortByName(passedRes.applicants)); 
+      setFailedList(sortByName(failedRes.applicants)); 
       setPassedTemplate(passedRes.template.content);
       setFailedTemplate(failedRes.template.content);
       setIsLoaded(true);

--- a/src/components/interview/InterviewContent.tsx
+++ b/src/components/interview/InterviewContent.tsx
@@ -13,8 +13,10 @@ import Loading from '@/components/ui/Loading';
 import { toast } from '@/components/Toast';
 import { applicantService } from '@/services/applicantService';
 import { authService } from '@/services/authService';
+import { projectService } from '@/services/projectService';
 import type { ApplicantRaw } from '@/types/applicant';
 import type { InterviewApplicant } from '@/types/interview';
+import type { ProjectState } from '@/types/project';
 
 const statusMap: Record<string, '보류' | '합격' | '불합격'> = {
   HOLD: '보류',
@@ -79,6 +81,15 @@ export default function InterviewContent({ projectId }: { projectId: number }) {
   const [selectedAppointmentTime, setSelectedAppointmentTime] = useState<string | undefined>();
   const [lastSyncedAt, setLastSyncedAt] = useState<Date>(new Date());
 
+  // 프로젝트 상태
+  const [projectState, setProjectState] = useState<ProjectState | null>(null);
+
+  // 면접 단계에 아직 진입하지 않았거나, 재활성화로 서류 단계로 되돌아간 상태
+  const isBeforeInterview = projectState === 'DOCUMENT' || projectState === 'DOCUMENT_COMPLETE';
+  // 위 경우 + 모든 절차가 종료된 경우는 쓰기 불가
+  const isReadOnly = isBeforeInterview || projectState === 'INTERVIEW_COMPLETE';
+
+  // 현재 유저 정보 조회
   useEffect(() => {
     const fetchCurrentUser = async () => {
       const auth = await authService.getCurrentUser();
@@ -89,7 +100,34 @@ export default function InterviewContent({ projectId }: { projectId: number }) {
     fetchCurrentUser();
   }, []);
 
+  // 프로젝트 상태 조회
   useEffect(() => {
+    const fetchProjectState = async () => {
+      try {
+        const projects = await projectService.getProjects();
+        const project = projects.find(p => p.id === projectId);
+        if (project) setProjectState(project.state);
+      } catch (e) {
+        console.error('프로젝트 상태 조회 실패:', e);
+        toast.error('프로젝트 정보를 불러오지 못했습니다.');
+        setIsLoading(false);
+      }
+    };
+    fetchProjectState();
+  }, [projectId]);
+
+  // 지원자 목록 조회 (프로젝트 상태 확정 이후에만 실행)
+  useEffect(() => {
+    if (projectState === null) return;
+
+    // 서류 단계로 되돌아간 프로젝트는 면접 목록을 노출하지 않는다
+    if (isBeforeInterview) {
+      setApplicants([]);
+      setFavorites(new Set());
+      setIsLoading(false);
+      return;
+    }
+
     const fetchApplicants = async () => {
       try {
         setIsLoading(true);
@@ -105,9 +143,10 @@ export default function InterviewContent({ projectId }: { projectId: number }) {
       }
     };
     fetchApplicants();
-  }, [projectId]);
+  }, [projectId, projectState, isBeforeInterview]);
 
   const handleRefresh = async () => {
+    if (isBeforeInterview) return;
     try {
       const res = await applicantService.getApplicants(projectId, 'INTERVIEW');
       const mapped = res.applicants.map(mapApplicant);
@@ -119,6 +158,10 @@ export default function InterviewContent({ projectId }: { projectId: number }) {
   };
 
   const handleStatusChange = async (applicantId: number, newStatus: '보류' | '합격' | '불합격') => {
+    if (isReadOnly) {
+      toast.error('종료된 단계라 면접 결과를 변경할 수 없습니다.');
+      return;
+    }
     try {
       await applicantService.updateStatus(projectId, applicantId, 'INTERVIEW', statusReverseMap[newStatus]);
       setApplicants(prev => prev.map(a => (a.applicantId === applicantId ? { ...a, interviewStatus: newStatus } : a)));
@@ -166,6 +209,7 @@ export default function InterviewContent({ projectId }: { projectId: number }) {
   );
 
   const handleToggleFavorite = async (applicantId: number) => {
+    if (isReadOnly) return;
     try {
       await applicantService.toggleBookmark(projectId, applicantId, 'INTERVIEW');
       setFavorites(prev => {
@@ -180,6 +224,11 @@ export default function InterviewContent({ projectId }: { projectId: number }) {
 
   const handleAppointmentConfirm = async (date: string, time: string, rawDate: string) => {
     if (!selectedAppointmentApplicantId) return;
+    if (isReadOnly) {
+      toast.error('종료된 단계라 면접 일정을 변경할 수 없습니다.');
+      setIsAppointmentOpen(false);
+      return;
+    }
     try {
       await applicantService.manualAssignInterview(projectId, selectedAppointmentApplicantId, rawDate, time);
       setApplicants(prev =>
@@ -192,6 +241,17 @@ export default function InterviewContent({ projectId }: { projectId: number }) {
       toast.error('면접 일정 저장에 실패했습니다.');
     }
   };
+
+  // 서류 단계로 재활성화된 프로젝트
+  if (!isLoading && isBeforeInterview) {
+    return (
+      <div className="flex flex-col items-center justify-center h-[calc(100vh-200px)] px-5">
+        <h2 className="text-subtitle-md text-black mb-2">아직 면접 단계가 아닙니다.</h2>
+        <p className="text-body-rg text-gray-500 text-center">서류 심사를 마치고 면접 단계로 이동하면</p>
+        <p className="text-body-rg text-gray-500 text-center">이곳에서 면접 대상자를 관리할 수 있습니다.</p>
+      </div>
+    );
+  }
 
   if (!isLoading && applicants.length === 0) {
     return (
@@ -286,6 +346,7 @@ export default function InterviewContent({ projectId }: { projectId: number }) {
         applicantId={selectedApplicantId}
         stage="INTERVIEW"
         currentUserId={currentUserId}
+        readOnly={isReadOnly}
       />
 
       <AppointmentModal

--- a/src/components/interview/InterviewDetailClient.tsx
+++ b/src/components/interview/InterviewDetailClient.tsx
@@ -11,7 +11,9 @@ import Loading from '@/components/ui/Loading';
 import { toast } from '@/components/Toast';
 import { applicantService } from '@/services/applicantService';
 import { authService } from '@/services/authService';
+import { projectService } from '@/services/projectService';
 import type { ApplicantDetail } from '@/types/applicant';
+import type { ProjectState } from '@/types/project';
 
 const genderMap: Record<string, '남' | '여'> = {
   MALE: '남',
@@ -62,6 +64,15 @@ export default function InterviewDetailClient({
   const [appointmentTime, setAppointmentTime] = useState(decodeURIComponent(initialTime));
   const [currentUserId, setCurrentUserId] = useState<number>(0);
 
+  // 프로젝트 상태
+  const [projectState, setProjectState] = useState<ProjectState | null>(null);
+  const [isProjectStateFailed, setIsProjectStateFailed] = useState(false);
+
+  // 면접 단계에 아직 진입하지 않았거나, 재활성화로 서류 단계로 되돌아간 상태
+  const isBeforeInterview = projectState === 'DOCUMENT' || projectState === 'DOCUMENT_COMPLETE';
+  // 위 경우 + 모든 절차가 종료된 경우는 쓰기 불가
+  const isReadOnly = isBeforeInterview || projectState === 'INTERVIEW_COMPLETE';
+
   const scrollToCommentId = searchParams.get('commentId') ? Number(searchParams.get('commentId')) : undefined;
 
   const formatPhoneNumber = (phone: string) => {
@@ -85,12 +96,35 @@ export default function InterviewDetailClient({
     fetchCurrentUser();
   }, []);
 
-  // 알림에서 openComment=true로 진입 시 바텀시트 자동 오픈
+  // 프로젝트 상태 조회
   useEffect(() => {
+    const fetchProjectState = async () => {
+      try {
+        const projects = await projectService.getProjects();
+        const project = projects.find(p => p.id === projectId);
+        if (project) {
+          setProjectState(project.state);
+        } else {
+          setIsProjectStateFailed(true);
+          setIsLoading(false);
+        }
+      } catch (e) {
+        console.error('프로젝트 상태 조회 실패:', e);
+        setIsProjectStateFailed(true);
+        setIsLoading(false);
+      }
+    };
+    fetchProjectState();
+  }, [projectId]);
+
+  // 알림에서 openComment=true로 진입 시 바텀시트 자동 오픈
+  // 서류 단계로 되돌아간 프로젝트에서는 열지 않는다
+  useEffect(() => {
+    if (isBeforeInterview) return;
     if (searchParams.get('openComment') === 'true') {
       setCommentOpen(true);
     }
-  }, [searchParams]);
+  }, [searchParams, isBeforeInterview]);
 
   const fetchApplicant = async () => {
     try {
@@ -108,15 +142,31 @@ export default function InterviewDetailClient({
     }
   };
 
+  // 지원자 상세 조회 (프로젝트 상태 확정 이후에만 실행)
   useEffect(() => {
+    if (projectState === null) return;
+
+    // 서류 단계로 되돌아간 프로젝트는 면접 정보를 노출하지 않는다
+    if (isBeforeInterview) {
+      setApplicant(null);
+      setIsLoading(false);
+      return;
+    }
+
     fetchApplicant();
-  }, [projectId, applicantId]);
+  }, [projectId, applicantId, projectState, isBeforeInterview]);
 
   const handleRefresh = async () => {
+    if (isBeforeInterview) return;
     await fetchApplicant();
   };
 
   const handleConfirm = async (date: string, time: string, rawDate: string) => {
+    if (isReadOnly) {
+      toast.error('종료된 단계라 면접 일정을 변경할 수 없습니다.');
+      setIsModalOpen(false);
+      return;
+    }
     try {
       await applicantService.manualAssignInterview(projectId, applicantId, rawDate, time);
       setAppointmentDate(date);
@@ -129,6 +179,7 @@ export default function InterviewDetailClient({
   };
 
   const handleToggleFavorite = async () => {
+    if (isReadOnly) return;
     try {
       await applicantService.toggleBookmark(projectId, applicantId, 'INTERVIEW');
       setIsFavorite(prev => !prev);
@@ -139,6 +190,26 @@ export default function InterviewDetailClient({
 
   if (isLoading) {
     return <Loading fullScreen={false} />;
+  }
+
+  // 프로젝트 정보를 확인하지 못한 경우
+  if (isProjectStateFailed) {
+    return (
+      <div className="flex items-center justify-center h-[calc(100vh-200px)] px-5">
+        <p className="text-gray-400 text-center">프로젝트 정보를 불러오지 못했습니다.</p>
+      </div>
+    );
+  }
+
+  // 서류 단계로 재활성화된 프로젝트
+  if (isBeforeInterview) {
+    return (
+      <div className="flex flex-col items-center justify-center h-[calc(100vh-200px)] px-5">
+        <h2 className="text-subtitle-md text-black mb-2">아직 면접 단계가 아닙니다.</h2>
+        <p className="text-body-rg text-gray-500 text-center">서류 심사를 마치고 면접 단계로 이동하면</p>
+        <p className="text-body-rg text-gray-500 text-center">이곳에서 면접 정보를 확인할 수 있습니다.</p>
+      </div>
+    );
   }
 
   if (!applicant) {
@@ -167,7 +238,10 @@ export default function InterviewDetailClient({
               onCommentClick={() => setCommentOpen(true)}
               appointmentDate={appointmentDate}
               appointmentTime={appointmentTime}
-              onAppointmentClick={() => setIsModalOpen(true)}
+              onAppointmentClick={() => {
+                if (isReadOnly) return;
+                setIsModalOpen(true);
+              }}
             />
           </div>
 
@@ -189,6 +263,7 @@ export default function InterviewDetailClient({
         stage="INTERVIEW"
         currentUserId={currentUserId}
         scrollToCommentId={scrollToCommentId}
+        readOnly={isReadOnly}
       />
 
       <AppointmentModal

--- a/src/components/interview/InterviewResultContent.tsx
+++ b/src/components/interview/InterviewResultContent.tsx
@@ -13,6 +13,9 @@ interface InterviewResultContentProps {
   projectId: number;
 }
 
+const sortByName = (list: DocumentApplicantResult[]) =>
+  [...list].sort((a, b) => a.name.localeCompare(b.name, 'ko'));
+
 export default function InterviewResultContent({ projectId }: InterviewResultContentProps) {
   const [selectedTab, setSelectedTab] = useState<'합격자' | '불합격자'>('합격자');
   const [stats, setStats] = useState<DocumentResultStats | null>(null);
@@ -33,8 +36,8 @@ export default function InterviewResultContent({ projectId }: InterviewResultCon
         documentResultService.getInterviewResults(projectId, 'FAIL'),
       ]);
       setStats(passedRes.stats);
-      setPassedList(passedRes.applicants);
-      setFailedList(failedRes.applicants);
+      setPassedList(sortByName(passedRes.applicants));
+      setFailedList(sortByName(failedRes.applicants));
       setPassedTemplate(passedRes.template.content);
       setFailedTemplate(failedRes.template.content);
       setIsLoaded(true);


### PR DESCRIPTION
## 📝 작업 내용

QA 중 발견된 면접 단계 관련 이슈 2건을 수정했습니다.

### 1. 재활성화된 프로젝트에서 면접 정보가 노출되는 문제
서류 재활성화로 프로젝트 상태가 `INTERVIEW` → `DOCUMENT`로 롤백되어도, 면접 지원자 관리 페이지에서 서류 합격자 목록이 그대로 조회되고 면접 결과 변경·일정 배정까지 가능한 상태였습니다.
원인은 `InterviewContent`와 `InterviewDetailClient`에 프로젝트 상태 확인 로직이 없어, `stage=INTERVIEW` 조회 결과를 상태와 무관하게 그대로 렌더링하고 있었기 때문입니다. (`DocumentContent`에는 이미 `isReadOnly` 처리가 있었으나 면접 쪽에는 누락)
- 두 컴포넌트에 프로젝트 상태 조회 추가
- `DOCUMENT` / `DOCUMENT_COMPLETE` 상태에서 면접 지원자 조회를 차단하고 안내 화면 노출
- 면접 결과 변경, 일정 배정, 즐겨찾기 등 쓰기 동작 차단
- 알림 딥링크(`?openComment=true`)로 상세 진입 시 댓글 시트 자동 오픈 차단
- 프로젝트 정보 조회 실패와 지원자 없음을 구분해 표시

### 2. 결과 페이지 지원자 명단 정렬 기준 부재
합격/불합격자 명단이 서버 응답 순서 그대로 노출되어, 가나다순도 추가순도 아닌 상태였습니다. 프론트·서비스 계층 어디에도 정렬이 없어 서버 응답 순서에 그대로 의존하고 있었습니다.
- `DocumentResultContent`, `InterviewResultContent`에서 fetch 직후 이름 오름차순 정렬
- 명단 전체보기 / 명단 복사 / 전화번호 복사 / 개인별 메시지가 동일 배열을 공유하므로 최상단에서 한 번만 정렬
- 서류 지원자 관리 페이지 기본 정렬(`name-asc`)과 기준 통일

## 🔗 관련 이슈

resolves #
